### PR TITLE
Fixing bootstrap_themes.py django1.9 compatibility

### DIFF
--- a/bootstrap_themes/templatetags/bootstrap_themes.py
+++ b/bootstrap_themes/templatetags/bootstrap_themes.py
@@ -1,12 +1,16 @@
 from django import template
 from django.contrib.staticfiles.storage import staticfiles_storage
+from django.utils.safestring import mark_safe
 from .. import get_script, get_styles
 
 register = template.Library()
 
+
 @register.simple_tag
 def bootstrap_script(use_min=True):
-    return '<script type="text/javascript" src="%(script_file)s"></script>' % dict(script_file=get_script(use_min))
+    return mark_safe(
+        '<script type="text/javascript" src="%(script_file)s"></script>' % dict(script_file=get_script(use_min)))
+
 
 @register.simple_tag
 def bootstrap_styles(theme='default', type='min.css'):
@@ -18,4 +22,5 @@ def bootstrap_styles(theme='default', type='min.css'):
         subdir = type
         fileext = type
         mimetype = 'text/less'
-    return '<link rel="stylesheet" href="%(theme_file)s" type="%(mimetype)s">' % dict(theme_file=get_styles(theme, subdir, fileext), mimetype=mimetype)
+    return mark_safe('<link rel="stylesheet" href="%(theme_file)s" type="%(mimetype)s">' % dict(
+        theme_file=get_styles(theme, subdir, fileext), mimetype=mimetype))


### PR DESCRIPTION
Added mark_safe for turning off tags autoescaping as per https://docs.djangoproject.com/en/1.9/howto/custom-template-tags/#simple-tags